### PR TITLE
Remove dynamic flag

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ function format (document) {
 }
 
 function purty (document) {
-  const cmd = `purty ${document.fileName} --dynamic`
+  const cmd = `purty ${document.fileName}`
   const cwdCurrent = vscode.workspace.rootPath
   return new Promise((resolve, reject) => {
     exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {


### PR DESCRIPTION
It looks like support for `--dynamic`/`--static` was dropped with the 4.0 release: https://gitlab.com/joneshf/purty/tags/4.0.0