### PR TITLE
Remove dynamic flag from purty execution

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ function format (document) {
 }
 
 function purty (document) {
-  const cmd = `purty ${document.fileName} --dynamic`
+  const cmd = `purty ${document.fileName}`
   const cwdCurrent = vscode.workspace.rootPath
   return new Promise((resolve, reject) => {
     exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {


### PR DESCRIPTION
Purty v4 has dropped support for static and dynamic modes in favor of a new mode that works similar to elm-format and takes the current formating into account. I removed the flag from the child process
execution since it is no longer needed.

See: https://gitlab.com/joneshf/purty/blob/master/CHANGELOG.md#anchor-401