### PR TITLE
Drop `--dynamic` flag to match with purty 4.x

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ function format (document) {
 }
 
 function purty (document) {
-  const cmd = `purty ${document.fileName} --dynamic`
+  const cmd = `purty ${document.fileName}`
   const cwdCurrent = vscode.workspace.rootPath
   return new Promise((resolve, reject) => {
     exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {


### PR DESCRIPTION
The `--dynamic` flag has been dropped in purty 4.0.0 (it does something cleverer, more like elm-format, see [the changelog](https://gitlab.com/joneshf/purty/blob/master/CHANGELOG.md#anchor-400)) so this PR just removes it from your VS Code extension. I guess if we really wanted to support purty 3.x it could be turned into an option, but this feels sufficient to me. If you're not happy not supporting older versions lmk and I'll do a proper PR with options.