### PR TITLE
Use STDIN as source for purty format

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,18 +28,20 @@ function format (document) {
       console.log('err', err)
     })
 }
-
 function purty (document) {
-  const cmd = `purty ${document.fileName}`
+  const cmd = 'purty -'
+  const text = document.getText();
   const cwdCurrent = vscode.workspace.rootPath
   return new Promise((resolve, reject) => {
-    exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {
+    const childProcess = exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {
       if (err) {
         console.log('err', err)
         reject(err)
       }
       resolve({ stdout: stdout, stderr: stderr })
     })
+    childProcess.stdin.write(text)
+    childProcess.stdin.end()
   })
 }
 


### PR DESCRIPTION
Purty >4.1.0 supports STDIN as input source. This way we can use the text from the document directly and send it to the purty process. Purty will then respond with the formated content and we can replace the content in the editor. This way the file does not have to be saved before it is formated and VSCode's "format on save" should work as expected.

This should fix #5