### PR TITLE
Try to find purty executable from local node_modules folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,6 +1098,19 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1130,6 +1143,46 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
+		},
+		"pkg-up": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+			"requires": {
+				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				}
+			}
 		},
 		"prelude-ls": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
 		"eslint": "^6.0.1",
 		"typescript": "^3.5.2",
 		"vscode": "^1.1.34"
+	},
+	"dependencies": {
+		"pkg-up": "^3.1.0"
 	}
 }


### PR DESCRIPTION
I noticed that the extension wouldn't work unless you installed purty globally with `npm install -g purty`. 

First I attempted to fix this with `const cmd = '$(npm bin)/purty -'` in `extension.js`. However this didn't work on Windows because its terminal doesn't support this syntax.

Apparently `prettier-vscode` has [solved](https://github.com/prettier/prettier-vscode/blob/master/src/requirePkg.ts) this problem by traversing the filesystem up until it finds a `package.json` file. So I took inspiration from there and came up with a solution which works on both MacOS and Windows. 

In short, `findLocalPurty` function looks for the closest `package.json` file, which should be accompanied by the `node_modules` folder, which should contain the `.bin` folder, which should contain the `purty` executable. If this doesn't yield a result, it will fall back to `purty` which is the same as before.