### PR TITLE
Remove custom command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,6 @@
 					".purs"
 				]
 			}
-		],
-		"commands": [
-			{
-				"command": "extension.format-ps",
-				"title": "Format PureScript"
-			}
 		]
 	},
 	"scripts": {


### PR DESCRIPTION
The custom command is not necessary since formatting works with the built-in command. There is also no code implementing it so I imagine it's just a remnant from times passed. 