### PR TITLE
Add config option for exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add support for custom purty binary location
+
 ## 0.3.0
 - Add support for local purty (Thanks to @jukkhop)
 - Remove unused command (Thanks to @jukkhop)

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,9 +685,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,17 @@
 					".purs"
 				]
 			}
-		]
+		],
+		"configuration": {
+			"title": "Purty",
+			"properties": {
+				"purty.pathToPurty": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Specifies the location of the purty executable (if unspecified I will try \"cwd/node_modules/.bin/purty\" and then look in the `PATH` environment variable)."
+				}
+			}
+		}
 	},
 	"scripts": {
 		"postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
This PR adds a configuration option for the path to the executable to run. It also runs the eslint formatter on the js, and updates a dependency that npm audit told me was vulnerable.

Closes #9 