### PR TITLE
Add support for finding exe

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const { exec } = require('child_process')
 const path = require('path')
 const fs = require('fs')
 const pkgUp = require('pkg-up')
+const which = require('which');
 
 function activate(context) {
   console.log('Congratulations, your extension "vscode-purty" is now active!')
@@ -28,46 +29,94 @@ function format(document) {
       return [vscode.TextEdit.replace(wholeDocument, stdout)]
     })
     .catch(err => {
-      console.log('err', err)
-      vscode.window.showErrorMessage(`Error: ${err}`);
-      vscode.window.showInformationMessage('Do you have Purty installed? "npm install purty"');
+      // We have already checked that the exe exists and is executable, any errors
+      // at this point are most likely syntax errors that are better flagged by the
+      // linter, so we just log to the console and finish.
+      console.log(err);
+      return []; // We must return an array of edits, in this case nothing.
     })
 }
 
-function purty(document) {
+const purty = async (document) => {
   const configs = vscode.workspace.getConfiguration('purty');
-  const purtyCmd = getPurtyCmd(configs.pathToPurty, document.fileName)
-  const cmd = `${purtyCmd} -`;
+  // We use empty string to mean unspecified because it means that the setting
+  // can be edited without having to write json (`["string", "null"]` does not
+  // have this property).
+  const purtyCmd = await findPurty(document.fileName, configs.pathToPurty);
+  if (purtyCmd == null) {
+    vscode.window.showErrorMessage(`Error: Could not find location of purty exe.`);
+    vscode.window.showInformationMessage('Do you have purty installed? (`npm install purty`)');
+    vscode.window.showInformationMessage('Or you can specify the full path in settings.');
+    return Promise.reject("cannot find purty exe");
+  }
+  // Quotes make sure any strange characters in the path are escaped (single quotes would
+  // be better, but double quotes are more cross-platform (works on windows))
+  const cmd = `"${purtyCmd}" -`;
   const text = document.getText();
   const cwdCurrent = vscode.workspace.rootPath;
   return new Promise((resolve, reject) => {
     const childProcess = exec(cmd, { cwd: cwdCurrent }, (err, stdout, stderr) => {
       if (err) {
-        console.log('err', err)
-        reject(err)
+        reject(err);
       }
-      resolve({ stdout: stdout, stderr: stderr })
+      resolve({ stdout: stdout, stderr: stderr });
     })
-    childProcess.stdin.write(text)
-    childProcess.stdin.end()
+    childProcess.stdin.write(text);
+    childProcess.stdin.end();
   })
 }
 
-function findLocalPurty(fspath) {
-  try {
-    const pkgPath = pkgUp.sync({ cwd: fspath });
-    if (pkgPath) {
-      const purtyPath = path.resolve(
-        path.dirname(pkgPath),
-        'node_modules',
-        '.bin',
-        'purty'
-      );
-      if (fs.existsSync(purtyPath)) {
-        return purtyPath;
-      }
+/// Find the purty executable.
+///
+/// If a path is passed as an argument that is tested first,
+/// then/otherwise the location (<workspace_dir>/node_modules/.bin/purty) is searched,
+/// and finally the `PATH` environment variable used for a final search. If no executable
+/// is found, then the promise will be rejected.
+const findPurty = async (psFilePath, purtyPath) => {
+  if (purtyPath !== "") {
+    if (await canRun(purtyPath)) {
+      return purtyPath;
     }
-  } catch (e) {
+  }
+  const localPurty = await localPurtyPath(psFilePath);
+  if (await canRun(localPurty)) {
+    return localPurty;
+  }
+  try {
+    return await which('purty');
+  } catch (_) {
+  }
+  return null;
+}
+
+/// Does an executable at `exePath` exist and is it runnable?
+const canRun = async (exePath) => {
+  if (exePath == null) {
+    return false;
+  }
+  try {
+    await fs.promises.access(exePath, fs.constants.X_OK);
+    return true;
+  } catch (_) {
+  }
+  return false;
+}
+
+/// Get the location that `npm install purty` would install purty to. If no file
+/// exists there or it is not executable, return `null`.
+const localPurtyPath = async (cwd) => {
+  try {
+    const workspacePath = await pkgUp({ cwd });
+    const purtyPath = path.resolve(
+      path.dirname(workspacePath),
+      'node_modules',
+      '.bin',
+      'purty'
+    );
+    if (await canRun(purtyPath)) {
+      return purtyPath;
+    }
+  } catch (_) {
   }
   return null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,6 +267,15 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -809,8 +818,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -1581,10 +1589,9 @@
 			}
 		},
 		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+			"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
 			"requires": {
 				"isexe": "^2.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,12 @@
 		"vscode": "^1.1.36"
 	},
 	"dependencies": {
-		"pkg-up": "^3.1.0"
+		"pkg-up": "^3.1.0",
+		"which": "^2.0.1"
+	},
+	"__metadata": {
+		"id": "d39a6373-b60a-4384-b464-90140c2683bd",
+		"publisherDisplayName": "Mika Vakula",
+		"publisherId": "f5558152-3a37-46c1-b65e-b76e63d275c5"
 	}
 }


### PR DESCRIPTION
I've been having problems with error messages popping up from purty when I have a syntax error that purty can't cope with. So I made a change to search for the exe, and only report errors when vscode can't find it. We can then only show error messages on that occasion, and hide them the rest of the time.

It's a fairly big change, so I'd understand if you don't want to accept it. I'm using it on my computer, and thought I should at least share it with the community :).